### PR TITLE
Fix cloudinary upload & response data of invalid token exceptions

### DIFF
--- a/flashpay/apps/core/exceptions.py
+++ b/flashpay/apps/core/exceptions.py
@@ -42,8 +42,8 @@ def custom_exception_handler(exception: APIException, context: Dict[str, Any]) -
         return Response(
             data={
                 "status_code": exception_response.status_code,
-                "message": exception.detail["detail"],
-                "data": None,
+                "message": "Invalid Token",
+                "data": exception.detail,
             },
             status=exception_response.status_code,
         )

--- a/flashpay/settings/base.py
+++ b/flashpay/settings/base.py
@@ -46,6 +46,10 @@ ROOT_URLCONF = "flashpay.urls"
 
 SITE_ID = 1
 
+FILE_UPLOAD_MAX_MEMORY_SIZE = 1048576  # 1MB
+
+DATA_UPLOAD_MAX_MEMORY_SIZE = FILE_UPLOAD_MAX_MEMORY_SIZE
+
 
 # ==============================================================================
 # MIDDLEWARE SETTINGS


### PR DESCRIPTION
1. The Cloudinary upload does not seem to be broken. However, I've added a limit of **1MB** to every file upload.
**Reason:** The picture is displayed in a tiny region of the application, so 1MB should be enough



2. Also, I changed the response data whenever an invalid access/refresh token was encountered.